### PR TITLE
chore(ci): add pre-commit hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+# EXAMPLE USAGE:
+#   https://lefthook.dev/configuration/
+pre-commit:
+  parallel: true
+  jobs:
+    - name: fmt
+      run: rustfmt {staged_files}
+      glob: "*.rs"
+    - name: clippy
+      run: cargo clippy --all-features --workspace -- -D warnings
+      glob: "*.rs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use esp_hal::{delay::Delay, prelude::*};
 extern crate alloc;
 use core::mem::MaybeUninit;
 
+#[allow(static_mut_refs)]
 fn init_heap() {
     const HEAP_SIZE: usize = 32 * 1024;
     static mut HEAP: MaybeUninit<[u8; HEAP_SIZE]> = MaybeUninit::uninit();


### PR DESCRIPTION
Adds a lefthook configuration to the repository. It triggers `cargo fmt` and `cargo clippy` on every commit.