### PR TITLE
chore(devcontainer): migrate to dependi

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
       "extensions": [
         "rust-lang.rust-analyzer",
         "tamasfe.even-better-toml",
-        "serayuzgur.crates",
+        "fill-labs.dependi",
         "mutantdino.resourcemonitor",
         "yzhang.markdown-all-in-one",
         "ms-vscode.cpptools",


### PR DESCRIPTION
[Crates](https://github.com/serayuzgur/crates?tab=readme-ov-file) is deprecated. Let's migrate to [Dependi](https://github.com/filllabs/dependi) as advised.